### PR TITLE
Fixed typo 'heard of cows' -> 'herd of cows'

### DIFF
--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -30,7 +30,7 @@ import {
                 ""
               ) : (
                 <Text color={"white"} fontWeight="bold" fontSize="2xl" >
-                  Heard of Cows
+                  Herd of Cows
                 </Text>
               )}
             </Flex>


### PR DESCRIPTION
Everywhere else on the repo it seems to be referred to as 'herd of cows', especially seeing as most people have heard of cows.

Also, token dropdowns are blank until hovered over and don't have any logos- I'll look into this when I have time this weekend

Closes #issue (optional)

_<Context of what this change does, why it is needed and how it is accomplished>_

### Test Plan

_<Explain how you and a reviewer have/intend to test this change>_
